### PR TITLE
[WIP] Support any order of arguments

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -16,11 +16,11 @@
     "default": {
         "attrs": {
             "hashes": [
-                "sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265",
-                "sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
+                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
+                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
             ],
             "index": "pypi",
-            "version": "==18.1.0"
+            "version": "==18.2.0"
         },
         "future": {
             "hashes": [
@@ -76,7 +76,7 @@
                 "sha256:37228cda29411948b422fae072f57e31d3396d2ee1c9783775980ee9c9990af6",
                 "sha256:58587dd4dc3daefad0487f6d9ae32b4542b185e1c36db6993290e7c41ca2b47c"
             ],
-            "markers": "python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version >= '2.7'",
+            "markers": "python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.0.*' and python_version != '3.1.*'",
             "version": "==1.5"
         },
         "appdirs": {
@@ -88,18 +88,19 @@
         },
         "atomicwrites": {
             "hashes": [
-                "sha256:240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585",
-                "sha256:a24da68318b08ac9c9c45029f4a10371ab5b20e4226738e150e6e7c571630ae6"
+                "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
+                "sha256:ec9ae8adaae229e4f8446952d204a3e4b5fdd2d099f9be3aaf556120135fb3ee"
             ],
-            "version": "==1.1.5"
+            "markers": "python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*'",
+            "version": "==1.2.1"
         },
         "attrs": {
             "hashes": [
-                "sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265",
-                "sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
+                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
+                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
             ],
             "index": "pypi",
-            "version": "==18.1.0"
+            "version": "==18.2.0"
         },
         "black": {
             "hashes": [
@@ -172,7 +173,7 @@
                 "sha256:a7a84d5fa07a089186a329528f127c9d73b9de57f1a1131b82bb5320ee651f6a",
                 "sha256:fc155a6b553c66c838d1a22dba1dc9f5f505c43285a878c6f74a79c024750b83"
             ],
-            "markers": "python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version >= '2.7'",
+            "markers": "python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.0.*' and python_version != '3.1.*'",
             "version": "==1.5.0"
         },
         "flake8": {
@@ -232,16 +233,16 @@
                 "sha256:6e3836e39f4d36ae72840833db137f7b7d35105079aee6ec4a62d9f80d594dd1",
                 "sha256:95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1"
             ],
-            "markers": "python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version >= '2.7'",
+            "markers": "python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*'",
             "version": "==0.7.1"
         },
         "py": {
             "hashes": [
-                "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7",
-                "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"
+                "sha256:06a30435d058473046be836d3fc4f27167fd84c45b99704f2fb5509ef61f9af1",
+                "sha256:50402e9d1c9005d759426988a492e0edaadb7f4e68bcddfea586bc7432d009c6"
             ],
-            "markers": "python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version >= '2.7'",
-            "version": "==1.5.4"
+            "markers": "python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*'",
+            "version": "==1.6.0"
         },
         "pycodestyle": {
             "hashes": [
@@ -259,26 +260,26 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:3459a123ad5532852d36f6f4501dfe1acf4af1dd9541834a164666aa40395b02",
-                "sha256:96bfd45dbe863b447a3054145cd78a9d7f31475d2bce6111b133c0cc4f305118"
+                "sha256:453cbbbe5ce6db38717d282b758b917de84802af4288910c12442984bde7b823",
+                "sha256:a8a07f84e680482eb51e244370aaf2caa6301ef265f37c2bdefb3dd3b663f99d"
             ],
             "index": "pypi",
-            "version": "==3.7.2"
+            "version": "==3.8.0"
         },
         "pytest-cache": {
             "hashes": [
                 "sha256:be7468edd4d3d83f1e844959fd6e3fd28e77a481440a7118d430130ea31b07a9"
             ],
-            "markers": "python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version >= '2.7'",
+            "markers": "python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.0.*' and python_version != '3.1.*'",
             "version": "==1.0"
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:03aa752cf11db41d281ea1d807d954c4eda35cfa1b21d6971966cc041bbf6e2d",
-                "sha256:890fe5565400902b0c78b5357004aab1c814115894f4f21370e2433256a3eeec"
+                "sha256:513c425e931a0344944f84ea47f3956be0e416d95acbd897a44970c8d926d5d7",
+                "sha256:e360f048b7dae3f2f2a9a4d067b2dd6b6a015d384d1577c994a43f3f7cbad762"
             ],
             "index": "pypi",
-            "version": "==2.5.1"
+            "version": "==2.6.0"
         },
         "pytest-flake8": {
             "hashes": [
@@ -346,25 +347,26 @@
         },
         "toml": {
             "hashes": [
-                "sha256:8e86bd6ce8cc11b9620cb637466453d94f5d57ad86f17e98a98d1f73e3baab2d"
+                "sha256:380178cde50a6a79f9d2cf6f42a62a5174febe5eea4126fe4038785f1d888d42",
+                "sha256:a7901919d3e4f92ffba7ff40a9d697e35bbbc8a8049fe8da742f34c83606d957"
             ],
-            "version": "==0.9.4"
+            "version": "==0.9.6"
         },
         "tox": {
             "hashes": [
-                "sha256:37cf240781b662fb790710c6998527e65ca6851eace84d1595ee71f7af4e85f7",
-                "sha256:eb61aa5bcce65325538686f09848f04ef679b5cd9b83cc491272099b28739600"
+                "sha256:433bb93c57edae263150767e672a0d468ab4fefcc1958eb4013e56a670bb851e",
+                "sha256:bfb4e4efb7c61a54bc010a5c00fdbe0973bc4bdf04090bfcd3c93c901006177c"
             ],
             "index": "pypi",
-            "version": "==3.2.1"
+            "version": "==3.3.0"
         },
         "tqdm": {
             "hashes": [
-                "sha256:5ef526702c0d265d5a960a3b27f3971fac13c26cf0fb819294bfa71fc6026c88",
-                "sha256:a3364bd83ce4777320b862e3c8a93d7da91e20a95f06ef79bed7dd71c654cafa"
+                "sha256:18f1818ce951aeb9ea162ae1098b43f583f7d057b34d706f66939353d1208889",
+                "sha256:df02c0650160986bac0218bb07952245fc6960d23654648b5d5526ad5a4128c9"
             ],
-            "markers": "python_version >= '2.6' and python_version != '3.1.*' and python_version != '3.0.*'",
-            "version": "==4.25.0"
+            "markers": "python_version >= '2.6' and python_version != '3.0.*' and python_version != '3.1.*'",
+            "version": "==4.26.0"
         },
         "twine": {
             "hashes": [
@@ -379,7 +381,7 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version >= '2.6' and python_version < '4' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.0.*'",
+            "markers": "python_version >= '2.6' and python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.0.*' and python_version < '4' and python_version != '3.1.*'",
             "version": "==1.23"
         },
         "virtualenv": {
@@ -387,7 +389,7 @@
                 "sha256:2ce32cd126117ce2c539f0134eb89de91a8413a29baac49cbab3eb50e2026669",
                 "sha256:ca07b4c0b54e14a91af9f34d0919790b016923d157afda5efdde55c96718f752"
             ],
-            "markers": "python_version != '3.2.*' and python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*'",
+            "markers": "python_version != '3.2.*' and python_version != '3.0.*' and python_version >= '2.7' and python_version != '3.1.*'",
             "version": "==16.0.0"
         },
         "virtualenv-clone": {

--- a/src/related/fields.py
+++ b/src/related/fields.py
@@ -5,9 +5,12 @@ from attr import attrib, NOTHING
 from collections import OrderedDict
 from uuid import uuid4, UUID
 from datetime import date, datetime, time
-from six import string_types
+from six import string_types, PY2
 
 from . import _init_fields, types, converters, validators
+
+
+attrib_additional_kwargs = {} if PY2 else {'kw_only': True}
 
 
 def BooleanField(default=NOTHING, required=True, repr=True, cmp=True,
@@ -24,7 +27,7 @@ def BooleanField(default=NOTHING, required=True, repr=True, cmp=True,
     default = _init_fields.init_default(required, default, None)
     validator = _init_fields.init_validator(required, bool)
     return attrib(default=default, validator=validator, repr=repr, cmp=cmp,
-                  metadata=dict(key=key))
+                  metadata=dict(key=key), **attrib_additional_kwargs)
 
 
 def ChildField(cls, default=NOTHING, required=True, repr=True, cmp=True,
@@ -45,7 +48,8 @@ def ChildField(cls, default=NOTHING, required=True, repr=True, cmp=True,
         required, object if isinstance(cls, str) else cls
     )
     return attrib(default=default, convert=converter, validator=validator,
-                  repr=repr, cmp=cmp, metadata=dict(key=key))
+                  repr=repr, cmp=cmp, metadata=dict(key=key),
+                  **attrib_additional_kwargs)
 
 
 def DateField(formatter=types.DEFAULT_DATE_FORMAT, default=NOTHING,
@@ -64,7 +68,8 @@ def DateField(formatter=types.DEFAULT_DATE_FORMAT, default=NOTHING,
     converter = converters.to_date_field(formatter)
     return attrib(default=default, convert=converter, validator=validator,
                   repr=repr, cmp=cmp,
-                  metadata=dict(formatter=formatter, key=key))
+                  metadata=dict(formatter=formatter, key=key),
+                  **attrib_additional_kwargs)
 
 
 def DateTimeField(formatter=types.DEFAULT_DATETIME_FORMAT, default=NOTHING,
@@ -83,7 +88,8 @@ def DateTimeField(formatter=types.DEFAULT_DATETIME_FORMAT, default=NOTHING,
     converter = converters.to_datetime_field(formatter)
     return attrib(default=default, convert=converter, validator=validator,
                   repr=repr, cmp=cmp,
-                  metadata=dict(formatter=formatter, key=key))
+                  metadata=dict(formatter=formatter, key=key),
+                  **attrib_additional_kwargs)
 
 
 def TimeField(formatter=types.DEFAULT_TIME_FORMAT, default=NOTHING,
@@ -102,7 +108,8 @@ def TimeField(formatter=types.DEFAULT_TIME_FORMAT, default=NOTHING,
     converter = converters.to_time_field(formatter)
     return attrib(default=default, convert=converter, validator=validator,
                   repr=repr, cmp=cmp,
-                  metadata=dict(formatter=formatter, key=key))
+                  metadata=dict(formatter=formatter, key=key),
+                  **attrib_additional_kwargs)
 
 
 def FloatField(default=NOTHING, required=True, repr=True, cmp=True,
@@ -120,7 +127,7 @@ def FloatField(default=NOTHING, required=True, repr=True, cmp=True,
     validator = _init_fields.init_validator(required, float)
     return attrib(default=default, convert=converters.float_if_not_none,
                   validator=validator, repr=repr, cmp=cmp,
-                  metadata=dict(key=key))
+                  metadata=dict(key=key), **attrib_additional_kwargs)
 
 
 def IntegerField(default=NOTHING, required=True, repr=True, cmp=True,
@@ -138,7 +145,7 @@ def IntegerField(default=NOTHING, required=True, repr=True, cmp=True,
     validator = _init_fields.init_validator(required, int)
     return attrib(default=default, convert=converters.int_if_not_none,
                   validator=validator, repr=repr, cmp=cmp,
-                  metadata=dict(key=key))
+                  metadata=dict(key=key), **attrib_additional_kwargs)
 
 
 def MappingField(cls, child_key, default=NOTHING, required=True, repr=False,
@@ -158,7 +165,8 @@ def MappingField(cls, child_key, default=NOTHING, required=True, repr=False,
     converter = converters.to_mapping_field(cls, child_key)
     validator = _init_fields.init_validator(required, types.TypedMapping)
     return attrib(default=default, convert=converter, validator=validator,
-                  repr=repr, metadata=dict(key=key))
+                  repr=repr, metadata=dict(key=key),
+                  **attrib_additional_kwargs)
 
 
 def RegexField(regex, default=NOTHING, required=True, repr=True, cmp=True,
@@ -177,7 +185,7 @@ def RegexField(regex, default=NOTHING, required=True, repr=True, cmp=True,
                                             validators.regex(regex))
     return attrib(default=default, convert=converters.str_if_not_none,
                   validator=validator, repr=repr, cmp=cmp,
-                  metadata=dict(key=key))
+                  metadata=dict(key=key), **attrib_additional_kwargs)
 
 
 def SequenceField(cls, default=NOTHING, required=True, repr=False, key=None):
@@ -195,7 +203,8 @@ def SequenceField(cls, default=NOTHING, required=True, repr=False, key=None):
     converter = converters.to_sequence_field(cls)
     validator = _init_fields.init_validator(required, types.TypedSequence)
     return attrib(default=default, convert=converter, validator=validator,
-                  repr=repr, metadata=dict(key=key))
+                  repr=repr, metadata=dict(key=key),
+                  **attrib_additional_kwargs)
 
 
 def SetField(cls, default=NOTHING, required=True, repr=False, key=None):
@@ -213,7 +222,8 @@ def SetField(cls, default=NOTHING, required=True, repr=False, key=None):
     converter = converters.to_set_field(cls)
     validator = _init_fields.init_validator(required, types.TypedSet)
     return attrib(default=default, convert=converter, validator=validator,
-                  repr=repr, metadata=dict(key=key))
+                  repr=repr, metadata=dict(key=key),
+                  **attrib_additional_kwargs)
 
 
 def StringField(default=NOTHING, required=True, repr=True, cmp=True,
@@ -231,7 +241,7 @@ def StringField(default=NOTHING, required=True, repr=True, cmp=True,
     validator = _init_fields.init_validator(required, string_types)
     return attrib(default=default, convert=converters.str_if_not_none,
                   validator=validator, repr=repr, cmp=cmp,
-                  metadata=dict(key=key))
+                  metadata=dict(key=key), **attrib_additional_kwargs)
 
 
 def URLField(default=NOTHING, required=False, repr=True, cmp=True, key=None):
@@ -249,7 +259,7 @@ def URLField(default=NOTHING, required=False, repr=True, cmp=True, key=None):
     validator = _init_fields.init_validator(required, cls)
     return attrib(default=default, convert=converters.str_to_url,
                   validator=validator, repr=repr, cmp=cmp,
-                  metadata=dict(key=key))
+                  metadata=dict(key=key), **attrib_additional_kwargs)
 
 
 def UUIDField(default=NOTHING, required=False, repr=True, cmp=True, key=None):
@@ -267,7 +277,7 @@ def UUIDField(default=NOTHING, required=False, repr=True, cmp=True, key=None):
     validator = _init_fields.init_validator(required, cls)
     return attrib(default=default, convert=converters.str_to_uuid,
                   validator=validator, repr=repr, cmp=cmp,
-                  metadata=dict(key=key))
+                  metadata=dict(key=key), **attrib_additional_kwargs)
 
 
 def DecimalField(default=NOTHING, required=True, repr=True, cmp=True,
@@ -285,4 +295,4 @@ def DecimalField(default=NOTHING, required=True, repr=True, cmp=True,
     validator = _init_fields.init_validator(required, Decimal)
     return attrib(default=default, convert=lambda x: Decimal(x),
                   validator=validator, repr=repr, cmp=cmp,
-                  metadata=dict(key=key))
+                  metadata=dict(key=key), **attrib_additional_kwargs)

--- a/tests/issues/test_issue_020.py
+++ b/tests/issues/test_issue_020.py
@@ -1,0 +1,12 @@
+import related
+
+
+@related.immutable
+class ImageOptions(object):
+    registry = related.URLField(required=False)
+    email = related.StringField(required=True)
+
+
+def test_non_required_first_no_exceptions():
+    ImageOptions(registry='http://example.com',
+                 email='email@example.com')


### PR DESCRIPTION
Proposed solution for #20 for Python 3+

`attrs` introduced `kw_only` argument in `18.2.0`, which will resolve any incorrect ordering issues, but we'll still need to handle this for Python 2.

@imaurer Can you help me get this PR to the finish line? Also, any proposals for handling this for Python 2?