### PR TITLE
Fix cmp deprecation warnings, pass **kwargs to attrib

### DIFF
--- a/src/related/fields.py
+++ b/src/related/fields.py
@@ -10,25 +10,26 @@ from six import string_types
 from . import _init_fields, types, converters, validators
 
 
-def BooleanField(default=NOTHING, required=True, repr=True, cmp=True,
-                 key=None):
+def BooleanField(default=NOTHING, required=True, repr=True,
+                 key=None, **kwargs):
     """
     Create new bool field on a model.
 
     :param default: any boolean value
     :param bool required: whether or not the object is invalid if not provided.
     :param bool repr: include this field should appear in object's repr.
-    :param bool cmp: include this field in generated comparison.
     :param string key: override name of the value when converted to dict.
+    :param \\**kwargs: keyword arguments passed to ``attrib()``
     """
     default = _init_fields.init_default(required, default, None)
     validator = _init_fields.init_validator(required, bool)
-    return attrib(default=default, validator=validator, repr=repr, cmp=cmp,
-                  metadata=dict(key=key))
+    return attrib(default=default, validator=validator, repr=repr,
+                  metadata=dict(key=key),
+                  **kwargs)
 
 
-def ChildField(cls, default=NOTHING, required=True, repr=True, cmp=True,
-               key=None):
+def ChildField(cls, default=NOTHING, required=True, repr=True,
+               key=None, **kwargs):
     """
     Create new child field on a model.
 
@@ -36,8 +37,8 @@ def ChildField(cls, default=NOTHING, required=True, repr=True, cmp=True,
     :param default: any object value of type cls
     :param bool required: whether or not the object is invalid if not provided.
     :param bool repr: include this field should appear in object's repr.
-    :param bool cmp: include this field in generated comparison.
     :param string key: override name of the value when converted to dict.
+    :param \\**kwargs: keyword arguments passed to ``attrib()``
     """
     default = _init_fields.init_default(required, default, None)
     converter = converters.to_child_field(cls)
@@ -45,11 +46,12 @@ def ChildField(cls, default=NOTHING, required=True, repr=True, cmp=True,
         required, object if isinstance(cls, str) else cls
     )
     return attrib(default=default, converter=converter, validator=validator,
-                  repr=repr, cmp=cmp, metadata=dict(key=key))
+                  repr=repr, metadata=dict(key=key),
+                  **kwargs)
 
 
 def DateField(formatter=types.DEFAULT_DATE_FORMAT, default=NOTHING,
-              required=True, repr=True, cmp=True, key=None):
+              required=True, repr=True, key=None, **kwargs):
     """
     Create new date field on a model.
 
@@ -57,19 +59,20 @@ def DateField(formatter=types.DEFAULT_DATE_FORMAT, default=NOTHING,
     :param default: any date or string that can be converted to a date value
     :param bool required: whether or not the object is invalid if not provided.
     :param bool repr: include this field should appear in object's repr.
-    :param bool cmp: include this field in generated comparison.
     :param string key: override name of the value when converted to dict.
+    :param \\**kwargs: keyword arguments passed to ``attrib()``
     """
     default = _init_fields.init_default(required, default, None)
     validator = _init_fields.init_validator(required, date)
     converter = converters.to_date_field(formatter)
     return attrib(default=default, converter=converter, validator=validator,
-                  repr=repr, cmp=cmp,
-                  metadata=dict(formatter=formatter, key=key))
+                  repr=repr,
+                  metadata=dict(formatter=formatter, key=key),
+                  **kwargs)
 
 
 def DateTimeField(formatter=types.DEFAULT_DATETIME_FORMAT, default=NOTHING,
-                  required=True, repr=True, cmp=True, key=None):
+                  required=True, repr=True, key=None, **kwargs):
     """
     Create new datetime field on a model.
 
@@ -77,19 +80,20 @@ def DateTimeField(formatter=types.DEFAULT_DATETIME_FORMAT, default=NOTHING,
     :param default: any datetime or string that can be converted to a datetime
     :param bool required: whether or not the object is invalid if not provided.
     :param bool repr: include this field should appear in object's repr.
-    :param bool cmp: include this field in generated comparison.
     :param string key: override name of the value when converted to dict.
+    :param \\**kwargs: keyword arguments passed to ``attrib()``
     """
     default = _init_fields.init_default(required, default, None)
     validator = _init_fields.init_validator(required, datetime)
     converter = converters.to_datetime_field(formatter)
     return attrib(default=default, converter=converter, validator=validator,
-                  repr=repr, cmp=cmp,
-                  metadata=dict(formatter=formatter, key=key))
+                  repr=repr,
+                  metadata=dict(formatter=formatter, key=key),
+                  **kwargs)
 
 
 def TimeField(formatter=types.DEFAULT_TIME_FORMAT, default=NOTHING,
-              required=True, repr=True, cmp=True, key=None):
+              required=True, repr=True, key=None, **kwargs):
     """
     Create new time field on a model.
 
@@ -97,55 +101,57 @@ def TimeField(formatter=types.DEFAULT_TIME_FORMAT, default=NOTHING,
     :param default: any time or string that can be converted to a time value
     :param bool required: whether or not the object is invalid if not provided.
     :param bool repr: include this field should appear in object's repr.
-    :param bool cmp: include this field in generated comparison.
     :param string key: override name of the value when converted to dict.
+    :param \\**kwargs: keyword arguments passed to ``attrib()``
     """
     default = _init_fields.init_default(required, default, None)
     validator = _init_fields.init_validator(required, time)
     converter = converters.to_time_field(formatter)
     return attrib(default=default, converter=converter, validator=validator,
-                  repr=repr, cmp=cmp,
-                  metadata=dict(formatter=formatter, key=key))
+                  repr=repr,
+                  metadata=dict(formatter=formatter, key=key),
+                  **kwargs)
 
 
-def FloatField(default=NOTHING, required=True, repr=True, cmp=True,
-               key=None):
+def FloatField(default=NOTHING, required=True, repr=True, key=None, **kwargs):
     """
     Create new float field on a model.
 
     :param default: any float value
     :param bool required: whether or not the object is invalid if not provided.
     :param bool repr: include this field should appear in object's repr.
-    :param bool cmp: include this field in generated comparison.
     :param string key: override name of the value when converted to dict.
+    :param \\**kwargs: keyword arguments passed to ``attrib()``
     """
     default = _init_fields.init_default(required, default, None)
     validator = _init_fields.init_validator(required, float)
     return attrib(default=default, converter=converters.float_if_not_none,
-                  validator=validator, repr=repr, cmp=cmp,
-                  metadata=dict(key=key))
+                  validator=validator, repr=repr,
+                  metadata=dict(key=key),
+                  **kwargs)
 
 
-def IntegerField(default=NOTHING, required=True, repr=True, cmp=True,
-                 key=None):
+def IntegerField(default=NOTHING, required=True, repr=True,
+                 key=None, **kwargs):
     """
     Create new int field on a model.
 
     :param default: any integer value
     :param bool required: whether or not the object is invalid if not provided.
     :param bool repr: include this field should appear in object's repr.
-    :param bool cmp: include this field in generated comparison.
     :param string key: override name of the value when converted to dict.
+    :param \\**kwargs: keyword arguments passed to ``attrib()``
     """
     default = _init_fields.init_default(required, default, None)
     validator = _init_fields.init_validator(required, int)
     return attrib(default=default, converter=converters.int_if_not_none,
-                  validator=validator, repr=repr, cmp=cmp,
-                  metadata=dict(key=key))
+                  validator=validator, repr=repr,
+                  metadata=dict(key=key),
+                  **kwargs)
 
 
 def MappingField(cls, child_key, default=NOTHING, required=True, repr=False,
-                 key=None):
+                 key=None, **kwargs):
     """
     Create new mapping field on a model.
 
@@ -154,18 +160,19 @@ def MappingField(cls, child_key, default=NOTHING, required=True, repr=False,
     :param default: any mapping type
     :param bool required: whether or not the object is invalid if not provided.
     :param bool repr: include this field should appear in object's repr.
-    :param bool cmp: include this field in generated comparison.
     :param string key: override name of the value when converted to dict.
+    :param \\**kwargs: keyword arguments passed to ``attrib()``
     """
     default = _init_fields.init_default(required, default, OrderedDict())
     converter = converters.to_mapping_field(cls, child_key)
     validator = _init_fields.init_validator(required, types.TypedMapping)
     return attrib(default=default, converter=converter, validator=validator,
-                  repr=repr, metadata=dict(key=key))
+                  repr=repr, metadata=dict(key=key),
+                  **kwargs)
 
 
-def RegexField(regex, default=NOTHING, required=True, repr=True, cmp=True,
-               key=None):
+def RegexField(regex, default=NOTHING, required=True, repr=True,
+               key=None, **kwargs):
     """
     Create new str field on a model.
 
@@ -173,18 +180,20 @@ def RegexField(regex, default=NOTHING, required=True, repr=True, cmp=True,
     :param default: any string value
     :param bool required: whether or not the object is invalid if not provided.
     :param bool repr: include this field should appear in object's repr.
-    :param bool cmp: include this field in generated comparison.
     :param string key: override name of the value when converted to dict.
+    :param \\**kwargs: keyword arguments passed to ``attrib()``
     """
     default = _init_fields.init_default(required, default, None)
     validator = _init_fields.init_validator(required, string_types,
                                             validators.regex(regex))
     return attrib(default=default, converter=converters.str_if_not_none,
-                  validator=validator, repr=repr, cmp=cmp,
-                  metadata=dict(key=key))
+                  validator=validator, repr=repr,
+                  metadata=dict(key=key),
+                  **kwargs)
 
 
-def SequenceField(cls, default=NOTHING, required=True, repr=False, key=None):
+def SequenceField(cls, default=NOTHING, required=True, repr=False, key=None,
+                  **kwargs):
     """
     Create new sequence field on a model.
 
@@ -192,17 +201,19 @@ def SequenceField(cls, default=NOTHING, required=True, repr=False, key=None):
     :param default: any TypedSequence or list
     :param bool required: whether or not the object is invalid if not provided.
     :param bool repr: include this field should appear in object's repr.
-    :param bool cmp: include this field in generated comparison.
     :param string key: override name of the value when converted to dict.
+    :param \\**kwargs: keyword arguments passed to ``attrib()``
     """
     default = _init_fields.init_default(required, default, [])
     converter = converters.to_sequence_field(cls)
     validator = _init_fields.init_validator(required, types.TypedSequence)
     return attrib(default=default, converter=converter, validator=validator,
-                  repr=repr, metadata=dict(key=key))
+                  repr=repr, metadata=dict(key=key),
+                  **kwargs)
 
 
-def SetField(cls, default=NOTHING, required=True, repr=False, key=None):
+def SetField(cls, default=NOTHING, required=True, repr=False, key=None,
+             **kwargs):
     """
     Create new set field on a model.
 
@@ -210,83 +221,87 @@ def SetField(cls, default=NOTHING, required=True, repr=False, key=None):
     :param default: any TypedSet or set
     :param bool required: whether or not the object is invalid if not provided.
     :param bool repr: include this field should appear in object's repr.
-    :param bool cmp: include this field in generated comparison.
     :param string key: override name of the value when converted to dict.
+    :param \\**kwargs: keyword arguments passed to ``attrib()``
     """
     default = _init_fields.init_default(required, default, set())
     converter = converters.to_set_field(cls)
     validator = _init_fields.init_validator(required, types.TypedSet)
     return attrib(default=default, converter=converter, validator=validator,
-                  repr=repr, metadata=dict(key=key))
+                  repr=repr, metadata=dict(key=key),
+                  **kwargs)
 
 
-def StringField(default=NOTHING, required=True, repr=True, cmp=True,
-                key=None):
+def StringField(default=NOTHING, required=True, repr=True, key=None, **kwargs):
     """
     Create new str field on a model.
 
     :param default: any string value
     :param bool required: whether or not the object is invalid if not provided.
     :param bool repr: include this field should appear in object's repr.
-    :param bool cmp: include this field in generated comparison.
     :param string key: override name of the value when converted to dict.
+    :param \\**kwargs: keyword arguments passed to ``attrib()``
     """
     default = _init_fields.init_default(required, default, None)
     validator = _init_fields.init_validator(required, string_types)
     return attrib(default=default, converter=converters.str_if_not_none,
-                  validator=validator, repr=repr, cmp=cmp,
-                  metadata=dict(key=key))
+                  validator=validator, repr=repr,
+                  metadata=dict(key=key),
+                  **kwargs)
 
 
-def URLField(default=NOTHING, required=True, repr=True, cmp=True, key=None):
+def URLField(default=NOTHING, required=True, repr=True, key=None, **kwargs):
     """
     Create new UUID field on a model.
 
     :param default: any value
     :param bool required: whether or not the object is invalid if not provided.
     :param bool repr: include this field should appear in object's repr.
-    :param bool cmp: include this field in generated comparison.
     :param string key: override name of the value when converted to dict.
+    :param \\**kwargs: keyword arguments passed to ``attrib()``
     """
     cls = ParseResult
     default = _init_fields.init_default(required, default, None)
     validator = _init_fields.init_validator(required, cls)
     return attrib(default=default, converter=converters.str_to_url,
-                  validator=validator, repr=repr, cmp=cmp,
-                  metadata=dict(key=key))
+                  validator=validator, repr=repr,
+                  metadata=dict(key=key),
+                  **kwargs)
 
 
-def UUIDField(default=NOTHING, required=False, repr=True, cmp=True, key=None):
+def UUIDField(default=NOTHING, required=False, repr=True, key=None, **kwargs):
     """
     Create new UUID field on a model.
 
     :param default: any value
     :param bool required: whether or not the object is invalid if not provided.
     :param bool repr: include this field should appear in object's repr.
-    :param bool cmp: include this field in generated comparison.
     :param string key: override name of the value when converted to dict.
+    :param \\**kwargs: keyword arguments passed to ``attrib()``
     """
     cls = UUID
     default = _init_fields.init_default(required, default, uuid4)
     validator = _init_fields.init_validator(required, cls)
     return attrib(default=default, converter=converters.str_to_uuid,
-                  validator=validator, repr=repr, cmp=cmp,
-                  metadata=dict(key=key))
+                  validator=validator, repr=repr,
+                  metadata=dict(key=key),
+                  **kwargs)
 
 
-def DecimalField(default=NOTHING, required=True, repr=True, cmp=True,
-                 key=None):
+def DecimalField(default=NOTHING, required=True, repr=True,
+                 key=None, **kwargs):
     """
     Create new decimal field on a model.
 
     :param default: any decimal value
     :param bool required: whether or not the object is invalid if not provided.
     :param bool repr: include this field should appear in object's repr.
-    :param bool cmp: include this field in generated comparison.
     :param string key: override name of the value when converted to dict.
+    :param \\**kwargs: keyword arguments passed to ``attrib()``
     """
     default = _init_fields.init_default(required, default, None)
     validator = _init_fields.init_validator(required, Decimal)
     return attrib(default=default, converter=lambda x: Decimal(x),
-                  validator=validator, repr=repr, cmp=cmp,
-                  metadata=dict(key=key))
+                  validator=validator, repr=repr,
+                  metadata=dict(key=key),
+                  **kwargs)

--- a/tests/ex02_compose_v3_2/models.py
+++ b/tests/ex02_compose_v3_2/models.py
@@ -17,7 +17,7 @@ class Mode(Enum):
 @related.immutable
 class Port(object):
     """ https://docs.docker.com/compose/compose-file/#ports """
-    _short_form = related.StringField(required=False, repr=False, cmp=False)
+    _short_form = related.StringField(required=False, repr=False, eq=False)
     target = related.IntegerField(required=False)
     published = related.IntegerField(required=False)
     protocol = related.ChildField(Protocol, default=Protocol.TCP)


### PR DESCRIPTION
Since attrs 19.2.0, the 'cmp' argument is deprecated and shows the
following:

    fields.py:27: DeprecationWarning: The usage of `cmp` is deprecated
    and will be removed on or after 2021-06-01.  Please use `eq` and
    `order` instead.
        metadata=dict(key=key))

There was no processing of the argument other than passing it through,
and the old default value (True) is equivalent to the current default of
attrs (None, like cmp=True but without the warning)

This commit solves the problem by not passing cmp explicitly, but
letting the user pass cmp (and get the deprecation warning, if they
still rely on it and shouldn't) or pass the new arguments, eq and order.

So the behavior should remain the same, but deprecation warnings won't
be raised by related, but by the users who actually pass an explicit
True or False to cmp.